### PR TITLE
fix(docker): 不再忽略 README.md，修复镜像构建失败

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,8 @@ __pycache__
 .gitignore
 
 # Docs & meta
-README.md
+# NOTE: README.md is NOT ignored — pyproject.toml references it (readme = ...)
+# and the Dockerfile COPYs it for `pip install -e .`.
 LICENSE
 AGENTS.md
 .dockerignore


### PR DESCRIPTION
## 问题

`bash scripts/build-and-push.sh` 在 `COPY pyproject.toml README.md ./` 这步失败：

```
ERROR: "/README.md": not found
```

根因：`.dockerignore` 把 `README.md` 排除了，但
- `pyproject.toml` 有 `readme = "README.md"`，`pip install -e .` 需要它；
- Dockerfile 显式 `COPY` 它。

## 修复

从 `.dockerignore` 移除 `README.md`（保留 LICENSE/AGENTS.md 的忽略），并加注释说明原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)