### PR TITLE
fix: code review 10 项全修复（0.2.1）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteam-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "M-Team CLI — keep-alive automation + AI-friendly data queries."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mteam_cli/__init__.py
+++ b/src/mteam_cli/__init__.py
@@ -1,3 +1,3 @@
 """M-Team CLI — keep-alive automation + AI-friendly data queries."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/mteam_cli/api/_internal.py
+++ b/src/mteam_cli/api/_internal.py
@@ -38,14 +38,15 @@ MTEAM_WEB_VERSION = os.getenv("MTEAM_WEB_VERSION", "1140")
 
 _SUCCESS_CODES = {"0", "200"}
 _AUTH_CODES = {"401", "403"}
-# Substrings in the API ``message`` that indicate an auth/permission problem.
-# Includes endpoints the API key can't reach (need a full web session): these
-# return "Full authentication is required" / "無許可權" / 401.
+# Substrings in the API ``message`` that UNAMBIGUOUSLY mean an auth/session
+# problem (bad key, or an endpoint that needs a full web session). Kept narrow
+# on purpose: broad words like "權限"/"permission"/"登录" also appear in normal
+# business errors (e.g. "您的等級不足，沒有下載權限" = a quota/level gate, NOT a
+# key problem), so matching them would misreport those as "API key invalid".
 _AUTH_HINTS = (
     "key無效", "key无效", "key invalid",
-    "未登", "登入", "登录", "鉴权", "鑒權",
-    "權限", "权限", "許可權", "许可权",
-    "authentication", "permission", "unauthor",
+    "無許可權", "无许可权",
+    "full authentication",
 )
 
 logger = logging.getLogger("mteam_cli.api")

--- a/src/mteam_cli/api/humanize.py
+++ b/src/mteam_cli/api/humanize.py
@@ -6,9 +6,16 @@ import humanize as _humanize
 
 
 def naturalsize(value: object) -> str:
-    """Human-readable binary size (MiB/GiB), matching the legacy script."""
+    """Human-readable binary size (MiB/GiB), matching the legacy script.
+
+    Coerces via ``float`` first so a byte count that arrives as a float- or
+    scientific-notation string (e.g. ``"12345.0"`` / ``"1.5e10"``) still
+    formats instead of falling through to an unscaled raw string.
+    """
+    if value in (None, ""):
+        return _humanize.naturalsize(0, binary=True)
     try:
-        return _humanize.naturalsize(int(value or 0), binary=True)
+        return _humanize.naturalsize(int(float(value)), binary=True)
     except (TypeError, ValueError):
         return str(value)
 

--- a/src/mteam_cli/automation/login.py
+++ b/src/mteam_cli/automation/login.py
@@ -212,7 +212,7 @@ async def _handle_2fa(
 
 def _parse_profile(profile: dict[str, Any], account: Account) -> str:
     """Format the intercepted profile into a notification body (legacy parity)."""
-    import humanize
+    from mteam_cli.api import humanize as hz
 
     data: dict[str, Any] | None = profile.get("data") if profile else None
     if not data:
@@ -236,13 +236,11 @@ def _parse_profile(profile: dict[str, Any], account: Account) -> str:
 
     count = data.get("memberCount")
     if count:
-        uploaded = humanize.naturalsize(count.get("uploaded", 0), binary=True)
-        downloaded = humanize.naturalsize(count.get("downloaded", 0), binary=True)
         lines += [
-            f"上传量: {uploaded}",
-            f"下载量: {downloaded}",
-            f"魔力值: {count.get('bonus')}",
-            f"分享率: {count.get('shareRate')}",
+            f"上传量: {hz.naturalsize(count.get('uploaded'))}",
+            f"下载量: {hz.naturalsize(count.get('downloaded'))}",
+            f"魔力值: {hz.num(count.get('bonus'))}",
+            f"分享率: {hz.ratio(count.get('shareRate'))}",
         ]
 
     return "\n".join(lines)

--- a/src/mteam_cli/cli/_account.py
+++ b/src/mteam_cli/cli/_account.py
@@ -42,3 +42,24 @@ def require_keepalive(account: Account) -> None:
             f"账户 {account.username!r} 缺少保活所需凭证"
             f"（需要 MTEAM_USERNAME/PASSWORD/TOTP_SECRET_<n>）。"
         )
+
+
+def resolve_session_or_exit(account: Account, settings: Settings):
+    """Load the web-session JWT for ``account``, or raise QueryExit(1).
+
+    Used by the session-only data commands (``hnr``/``messages``) that the API
+    key can't reach. Returns a ``WebSession``. Writes a stderr hint and unwinds
+    via ``QueryExit`` when no snapshot exists yet.
+    """
+    from mteam_cli.api import load_session
+    from mteam_cli.cli._emit import notice
+    from mteam_cli.cli._query import QueryExit
+
+    session = load_session(account.storage_path(settings.auth_dir))
+    if session is None:
+        notice(
+            f"该端点需要登录会话。请先运行 `mteam-cli login --account {account.username}`，"
+            "再执行本命令。"
+        )
+        raise QueryExit(1)
+    return session

--- a/src/mteam_cli/cli/_emit.py
+++ b/src/mteam_cli/cli/_emit.py
@@ -177,3 +177,12 @@ def emit_raw(data: Any) -> None:
     """Pretty-print the full API payload as JSON to stdout (pipe-clean)."""
     json.dump(data, sys.stdout, ensure_ascii=False, indent=2)
     sys.stdout.write("\n")
+
+
+def notice(message: str) -> None:
+    """Write a human diagnostic (error / empty-result hint) to stderr.
+
+    Keeps stdout pipe-clean for the machine formats — an error or empty result
+    under ``-f json`` must never put non-JSON text on stdout.
+    """
+    print(message, file=sys.stderr)

--- a/src/mteam_cli/cli/_emit.py
+++ b/src/mteam_cli/cli/_emit.py
@@ -148,6 +148,17 @@ def auto_fields(rows: list[dict[str, Any]], max_cols: int = 8) -> list[Field]:
     return [Field(k, k) for k in seen[:max_cols]]
 
 
+def has_nested_values(rows: list[dict[str, Any]]) -> bool:
+    """True if any row has a dict/list value (renders as ugly repr in a table).
+
+    Lets auto_fields-based commands warn the user to use ``--raw`` for a usable
+    view, instead of silently emitting ``{'id': 1, ...}`` repr cells.
+    """
+    return any(
+        isinstance(v, (dict, list)) for r in rows for v in r.values()
+    )
+
+
 def add_format_arg(parser: Any) -> None:
     """Inject ``-f/--format`` onto a subparser. Single source of truth."""
     parser.add_argument(

--- a/src/mteam_cli/cli/_query.py
+++ b/src/mteam_cli/cli/_query.py
@@ -1,0 +1,63 @@
+"""Shared scaffolding for the data-query commands.
+
+Every data command repeats the same tail: await an API call, turn
+``MTeamAPIError`` into a stderr diagnostic + exit 1, and short-circuit to raw
+JSON when ``--raw`` is set. Centralizing it here keeps that error/--raw/exit
+contract in ONE place so the 7 commands can't drift (they did before this).
+
+Commands still own what legitimately differs: account/session resolution and
+the row/record shaping.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Awaitable
+
+from mteam_cli.api import MTeamAPIError
+from mteam_cli.cli._emit import emit_raw, notice
+
+
+class QueryExit(Exception):
+    """Raised to unwind a command with a specific exit code (already reported)."""
+
+    def __init__(self, code: int) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+async def fetch(coro: Awaitable[Any]) -> Any:
+    """Await an API coroutine, converting ``MTeamAPIError`` to exit 1.
+
+    On error: writes ``错误: ...`` to stderr (keeping stdout pipe-clean) and
+    raises ``QueryExit(1)``. The command's ``handle`` wraps its body so this
+    unwinds cleanly — see ``run``.
+    """
+    try:
+        return await coro
+    except MTeamAPIError as exc:
+        notice(f"错误: {exc}")
+        raise QueryExit(1) from exc
+
+
+def maybe_raw(args: argparse.Namespace, data: Any) -> bool:
+    """If ``--raw`` was passed, dump the full payload and signal done.
+
+    Returns ``True`` when raw output was emitted (the command should return 0).
+    """
+    if getattr(args, "raw", False):
+        emit_raw(data)
+        return True
+    return False
+
+
+async def run(body: Awaitable[int]) -> int:
+    """Run a command body, translating a ``QueryExit`` into its exit code.
+
+    Lets command handlers call ``fetch``/``maybe_raw`` and shape data linearly
+    without nesting try/except in every file.
+    """
+    try:
+        return await body
+    except QueryExit as exit_:
+        return exit_.code

--- a/src/mteam_cli/cli/_table.py
+++ b/src/mteam_cli/cli/_table.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import unicodedata
+
 
 def cjk_visual_width(text: str) -> int:
-    """Approximate terminal display width: ASCII = 1, CJK = 2."""
-    cjk = sum(1 for c in text if "一" <= c <= "鿿" or "　" <= c <= "〿")
-    return len(text) + cjk
+    """Terminal display width: wide/fullwidth glyphs = 2, others = 1.
+
+    Uses ``unicodedata.east_asian_width`` so it covers not just the CJK
+    ideograph block but also fullwidth punctuation (， ： ！ etc.) and other
+    East-Asian wide ranges that a hand-rolled range check misses — those are
+    common in M-Team titles and would otherwise misalign every following column.
+    """
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in text)
 
 
 def pad_cell(text: str, width: int) -> str:

--- a/src/mteam_cli/cli/commands/detail.py
+++ b/src/mteam_cli/cli/commands/detail.py
@@ -9,7 +9,7 @@ from typing import Any
 from mteam_cli.api import MTeamAPIError, gen_dl_token, get_torrent_detail
 from mteam_cli.api import humanize as hz
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, emit_record
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_record
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -54,10 +54,10 @@ async def handle(
             account.api_key, args.id, base_url=settings.api_base_url
         )
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
     if not data:
-        print(f"未找到种子 {args.id}。")
+        notice(f"未找到种子 {args.id}。")
         return 1
 
     if args.raw:

--- a/src/mteam_cli/cli/commands/detail.py
+++ b/src/mteam_cli/cli/commands/detail.py
@@ -9,7 +9,8 @@ from typing import Any
 from mteam_cli.api import MTeamAPIError, gen_dl_token, get_torrent_detail
 from mteam_cli.api import humanize as hz
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_record
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_record, notice
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -47,21 +48,22 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings, logger))
+
+
+async def _run(
+    args: argparse.Namespace, settings: Settings, logger: logging.Logger
+) -> int:
     account = resolve_account_or_exit(args, settings)
     require_query(account)
-    try:
-        data = await get_torrent_detail(
-            account.api_key, args.id, base_url=settings.api_base_url
-        )
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
+
+    data = await fetch(
+        get_torrent_detail(account.api_key, args.id, base_url=settings.api_base_url)
+    )
     if not data:
         notice(f"未找到种子 {args.id}。")
         return 1
-
-    if args.raw:
-        emit_raw(data)
+    if maybe_raw(args, data):
         return 0
 
     record = _shape(data)

--- a/src/mteam_cli/cli/commands/hnr.py
+++ b/src/mteam_cli/cli/commands/hnr.py
@@ -13,7 +13,7 @@ import logging
 from mteam_cli.api import MTeamAPIError, get_hnr, load_session
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, emit_rows
+from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
 from mteam_cli.core.config import Settings
 
 
@@ -34,7 +34,7 @@ async def handle(
     account = resolve_account_or_exit(args, settings)
     session = load_session(account.storage_path(settings.auth_dir))
     if session is None:
-        print(
+        notice(
             f"该端点需要登录会话。请先运行 `mteam-cli login --account {account.username}`，"
             "再执行本命令。"
         )
@@ -42,7 +42,7 @@ async def handle(
 
     uid = args.uid or session.uid
     if not uid:
-        print("无法确定 uid（会话未携带，且未指定 --uid）。")
+        notice("无法确定 uid（会话未携带，且未指定 --uid）。")
         return 1
 
     try:
@@ -54,7 +54,7 @@ async def handle(
             visitorid=session.visitorid,
         )
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
 
     if args.raw:
@@ -63,7 +63,7 @@ async def handle(
 
     rows = as_list(data)
     if not rows:
-        print("无 H&R 记录。")
+        notice("无 H&R 记录。")
         return 0
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/hnr.py
+++ b/src/mteam_cli/cli/commands/hnr.py
@@ -10,10 +10,22 @@ from __future__ import annotations
 import argparse
 import logging
 
-from mteam_cli.api import MTeamAPIError, get_hnr, load_session
+from mteam_cli.api import get_hnr
 from mteam_cli.api.public import as_list
-from mteam_cli.cli._account import add_account_arg, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
+from mteam_cli.cli._account import (
+    add_account_arg,
+    resolve_account_or_exit,
+    resolve_session_or_exit,
+)
+from mteam_cli.cli._emit import (
+    add_format_arg,
+    add_raw_arg,
+    auto_fields,
+    emit_rows,
+    has_nested_values,
+    notice,
+)
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 
@@ -31,39 +43,35 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings))
+
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
     account = resolve_account_or_exit(args, settings)
-    session = load_session(account.storage_path(settings.auth_dir))
-    if session is None:
-        notice(
-            f"该端点需要登录会话。请先运行 `mteam-cli login --account {account.username}`，"
-            "再执行本命令。"
-        )
-        return 1
+    session = resolve_session_or_exit(account, settings)
 
     uid = args.uid or session.uid
     if not uid:
         notice("无法确定 uid（会话未携带，且未指定 --uid）。")
         return 1
 
-    try:
-        data = await get_hnr(
+    data = await fetch(
+        get_hnr(
             uid,
             base_url=settings.api_base_url,
             auth_token=session.auth_token,
             did=session.did,
             visitorid=session.visitorid,
         )
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
-
-    if args.raw:
-        emit_raw(data)
+    )
+    if maybe_raw(args, data):
         return 0
 
     rows = as_list(data)
     if not rows:
         notice("无 H&R 记录。")
         return 0
+    if args.output_format in ("table", "md") and has_nested_values(rows):
+        notice("提示：响应含嵌套字段，表格可能不易读，建议加 --raw 查看完整 JSON。")
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/messages.py
+++ b/src/mteam_cli/cli/commands/messages.py
@@ -10,10 +10,22 @@ from __future__ import annotations
 import argparse
 import logging
 
-from mteam_cli.api import MTeamAPIError, get_messages, load_session
+from mteam_cli.api import get_messages
 from mteam_cli.api.public import as_list
-from mteam_cli.cli._account import add_account_arg, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
+from mteam_cli.cli._account import (
+    add_account_arg,
+    resolve_account_or_exit,
+    resolve_session_or_exit,
+)
+from mteam_cli.cli._emit import (
+    add_format_arg,
+    add_raw_arg,
+    auto_fields,
+    emit_rows,
+    has_nested_values,
+    notice,
+)
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 
@@ -33,17 +45,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
-    account = resolve_account_or_exit(args, settings)
-    session = load_session(account.storage_path(settings.auth_dir))
-    if session is None:
-        notice(
-            f"该端点需要登录会话。请先运行 `mteam-cli login --account {account.username}`，"
-            "再执行本命令。"
-        )
-        return 1
+    return await run(_run(args, settings))
 
-    try:
-        data = await get_messages(
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
+    account = resolve_account_or_exit(args, settings)
+    session = resolve_session_or_exit(account, settings)
+
+    data = await fetch(
+        get_messages(
             base_url=settings.api_base_url,
             auth_token=session.auth_token,
             did=session.did,
@@ -52,17 +62,15 @@ async def handle(
             page_number=args.page,
             page_size=args.limit,
         )
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
-
-    if args.raw:
-        emit_raw(data)
+    )
+    if maybe_raw(args, data):
         return 0
 
     rows = as_list(data)
     if not rows:
         notice("无站内信。")
         return 0
+    if args.output_format in ("table", "md") and has_nested_values(rows):
+        notice("提示：响应含嵌套字段，表格可能不易读，建议加 --raw 查看完整 JSON。")
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/messages.py
+++ b/src/mteam_cli/cli/commands/messages.py
@@ -13,7 +13,7 @@ import logging
 from mteam_cli.api import MTeamAPIError, get_messages, load_session
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, emit_rows
+from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
 from mteam_cli.core.config import Settings
 
 
@@ -36,7 +36,7 @@ async def handle(
     account = resolve_account_or_exit(args, settings)
     session = load_session(account.storage_path(settings.auth_dir))
     if session is None:
-        print(
+        notice(
             f"该端点需要登录会话。请先运行 `mteam-cli login --account {account.username}`，"
             "再执行本命令。"
         )
@@ -53,7 +53,7 @@ async def handle(
             page_size=args.limit,
         )
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
 
     if args.raw:
@@ -62,7 +62,7 @@ async def handle(
 
     rows = as_list(data)
     if not rows:
-        print("无站内信。")
+        notice("无站内信。")
         return 0
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/notices.py
+++ b/src/mteam_cli/cli/commands/notices.py
@@ -9,10 +9,18 @@ from __future__ import annotations
 import argparse
 import logging
 
-from mteam_cli.api import MTeamAPIError, get_notices
+from mteam_cli.api import get_notices
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
+from mteam_cli.cli._emit import (
+    add_format_arg,
+    add_raw_arg,
+    auto_fields,
+    emit_rows,
+    has_nested_values,
+    notice,
+)
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 
@@ -27,21 +35,22 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings))
+
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
     account = resolve_account_or_exit(args, settings)
     require_query(account)
-    try:
-        data = await get_notices(account.api_key, base_url=settings.api_base_url)
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
 
-    if args.raw:
-        emit_raw(data)
+    data = await fetch(get_notices(account.api_key, base_url=settings.api_base_url))
+    if maybe_raw(args, data):
         return 0
 
     rows = as_list(data)
     if not rows:
         notice("无公告。")
         return 0
+    if args.output_format in ("table", "md") and has_nested_values(rows):
+        notice("提示：响应含嵌套字段，表格可能不易读，建议加 --raw 查看完整 JSON。")
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/notices.py
+++ b/src/mteam_cli/cli/commands/notices.py
@@ -12,7 +12,7 @@ import logging
 from mteam_cli.api import MTeamAPIError, get_notices
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, emit_rows
+from mteam_cli.cli._emit import add_format_arg, add_raw_arg, auto_fields, emit_raw, notice, emit_rows
 from mteam_cli.core.config import Settings
 
 
@@ -32,7 +32,7 @@ async def handle(
     try:
         data = await get_notices(account.api_key, base_url=settings.api_base_url)
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
 
     if args.raw:
@@ -41,7 +41,7 @@ async def handle(
 
     rows = as_list(data)
     if not rows:
-        print("无公告。")
+        notice("无公告。")
         return 0
     emit_rows(rows, auto_fields(rows), fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/profile.py
+++ b/src/mteam_cli/cli/commands/profile.py
@@ -9,7 +9,7 @@ from typing import Any
 from mteam_cli.api import MTeamAPIError, get_profile
 from mteam_cli.api import humanize as hz
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, emit_record
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_record
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -44,10 +44,10 @@ async def handle(
     try:
         data = await get_profile(account.api_key, base_url=settings.api_base_url, uid=args.uid)
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
     if not data:
-        print("未获取到 profile 数据。")
+        notice("未获取到 profile 数据。")
         return 1
 
     if args.raw:

--- a/src/mteam_cli/cli/commands/profile.py
+++ b/src/mteam_cli/cli/commands/profile.py
@@ -6,10 +6,11 @@ import argparse
 import logging
 from typing import Any
 
-from mteam_cli.api import MTeamAPIError, get_profile
+from mteam_cli.api import get_profile
 from mteam_cli.api import humanize as hz
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_record
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_record, notice
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -39,23 +40,23 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings))
+
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
     account = resolve_account_or_exit(args, settings)
     require_query(account)
-    try:
-        data = await get_profile(account.api_key, base_url=settings.api_base_url, uid=args.uid)
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
+
+    data = await fetch(
+        get_profile(account.api_key, base_url=settings.api_base_url, uid=args.uid)
+    )
     if not data:
         notice("未获取到 profile 数据。")
         return 1
-
-    if args.raw:
-        emit_raw(data)
+    if maybe_raw(args, data):
         return 0
 
-    record = _shape(data)
-    emit_record(record, _FIELDS, fmt=args.output_format)
+    emit_record(_shape(data), _FIELDS, fmt=args.output_format)
     return 0
 
 

--- a/src/mteam_cli/cli/commands/search.py
+++ b/src/mteam_cli/cli/commands/search.py
@@ -6,11 +6,12 @@ import argparse
 import logging
 from typing import Any
 
-from mteam_cli.api import MTeamAPIError, search_torrents
+from mteam_cli.api import search_torrents
 from mteam_cli.api import humanize as hz
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_rows
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_rows, notice
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -47,10 +48,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings))
+
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
     account = resolve_account_or_exit(args, settings)
     require_query(account)
-    try:
-        data = await search_torrents(
+
+    data = await fetch(
+        search_torrents(
             account.api_key,
             args.keyword,
             base_url=settings.api_base_url,
@@ -58,12 +64,8 @@ async def handle(
             page_number=args.page,
             page_size=args.limit,
         )
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
-
-    if args.raw:
-        emit_raw(data)
+    )
+    if maybe_raw(args, data):
         return 0
 
     rows = [_shape(t, i) for i, t in enumerate(as_list(data), start=1)]

--- a/src/mteam_cli/cli/commands/search.py
+++ b/src/mteam_cli/cli/commands/search.py
@@ -10,7 +10,7 @@ from mteam_cli.api import MTeamAPIError, search_torrents
 from mteam_cli.api import humanize as hz
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, emit_rows
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_rows
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -59,7 +59,7 @@ async def handle(
             page_size=args.limit,
         )
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
 
     if args.raw:
@@ -68,7 +68,7 @@ async def handle(
 
     rows = [_shape(t, i) for i, t in enumerate(as_list(data), start=1)]
     if not rows:
-        print("未找到结果。")
+        notice("未找到结果。")
         return 0
     emit_rows(rows, _FIELDS, fmt=args.output_format, footer=_FOOTER)
     return 0

--- a/src/mteam_cli/cli/commands/seeding.py
+++ b/src/mteam_cli/cli/commands/seeding.py
@@ -15,7 +15,7 @@ from mteam_cli.api import MTeamAPIError, get_own_uid, get_peer_list
 from mteam_cli.api import humanize as hz
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, emit_rows
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_rows
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -58,7 +58,7 @@ async def handle(
             page_size=args.limit,
         )
     except MTeamAPIError as exc:
-        print(f"错误: {exc}")
+        notice(f"错误: {exc}")
         return 1
 
     if args.raw:
@@ -67,7 +67,7 @@ async def handle(
 
     rows = [_shape(it) for it in as_list(data)]
     if not rows:
-        print("无下载中种子。" if args.leeching else "无做种中种子。")
+        notice("无下载中种子。" if args.leeching else "无做种中种子。")
         return 0
     emit_rows(rows, _FIELDS, fmt=args.output_format)
     return 0

--- a/src/mteam_cli/cli/commands/seeding.py
+++ b/src/mteam_cli/cli/commands/seeding.py
@@ -11,11 +11,12 @@ import argparse
 import logging
 from typing import Any
 
-from mteam_cli.api import MTeamAPIError, get_own_uid, get_peer_list
+from mteam_cli.api import get_own_uid, get_peer_list
 from mteam_cli.api import humanize as hz
 from mteam_cli.api.public import as_list
 from mteam_cli.cli._account import add_account_arg, require_query, resolve_account_or_exit
-from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_raw, notice, emit_rows
+from mteam_cli.cli._emit import Field, add_format_arg, add_raw_arg, emit_rows, notice
+from mteam_cli.cli._query import fetch, maybe_raw, run
 from mteam_cli.core.config import Settings
 
 _FIELDS = [
@@ -44,12 +45,20 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 async def handle(
     args: argparse.Namespace, settings: Settings, logger: logging.Logger
 ) -> int:
+    return await run(_run(args, settings))
+
+
+async def _run(args: argparse.Namespace, settings: Settings) -> int:
     account = resolve_account_or_exit(args, settings)
     require_query(account)
     base = settings.api_base_url
-    try:
-        uid = args.uid or await get_own_uid(account.api_key, base_url=base)
-        data = await get_peer_list(
+
+    # getUserTorrentList requires a userid (probe-confirmed: 參數錯誤 without
+    # it), so the default path costs one extra profile fetch to learn our own
+    # uid. Pass --uid to skip it.
+    uid = args.uid or await fetch(get_own_uid(account.api_key, base_url=base))
+    data = await fetch(
+        get_peer_list(
             account.api_key,
             uid,
             base_url=base,
@@ -57,12 +66,8 @@ async def handle(
             page_number=args.page,
             page_size=args.limit,
         )
-    except MTeamAPIError as exc:
-        notice(f"错误: {exc}")
-        return 1
-
-    if args.raw:
-        emit_raw(data)
+    )
+    if maybe_raw(args, data):
         return 0
 
     rows = [_shape(it) for it in as_list(data)]

--- a/src/mteam_cli/notify/telegram.py
+++ b/src/mteam_cli/notify/telegram.py
@@ -25,13 +25,17 @@ class TelegramNotifier:
     timeout_seconds: int = 15
 
     async def send(self, n: Notification) -> None:
-        text = f"*{n.title}*\n\n{n.body}"
+        # Plain text (no parse_mode): the body is a profile dump / error string
+        # that routinely contains Markdown metachars (e.g. '_' in usernames or
+        # 'qBittorrent/5.2.0'); parsing as Markdown would 400 and silently drop
+        # the alert.
+        text = f"{n.title}\n\n{n.body}"
         await asyncio.to_thread(self._send_message, text)
 
     def _send_message(self, text: str) -> None:
         url = f"{_TG_API}/bot{self.token}/sendMessage"
         data = urlencode(
-            {"chat_id": self.chat_id, "text": text, "parse_mode": "Markdown"}
+            {"chat_id": self.chat_id, "text": text}
         ).encode("utf-8")
         req = Request(
             url,

--- a/src/mteam_cli/scheduler/daily.py
+++ b/src/mteam_cli/scheduler/daily.py
@@ -38,7 +38,10 @@ class DailyScheduler:
 
     def pick_daily_time(self) -> str:
         start_min, end_min = _parse_window(self.settings.schedule_window)
-        chosen = random.randint(start_min, end_min)
+        # Support overnight / wrap-around windows (e.g. 23:00-06:00): when
+        # start > end, pick across the wrap and fold back into 0–1439.
+        span = end_min - start_min if end_min >= start_min else end_min + 1440 - start_min
+        chosen = (start_min + random.randint(0, span)) % 1440
         return f"{chosen // 60:02d}:{chosen % 60:02d}"
 
     def loop(self) -> None:


### PR DESCRIPTION
高强度 code review 后修复全部 10 项（4 真 bug + 1 体验 + 5 重构/优化），bump 到 0.2.1。

## 真 bug（#1–#4）
| # | 文件 | 修复 |
|---|---|---|
| 1 | `scheduler/daily.py` | 反转/跨夜窗口（`23:00-06:00`）不再崩溃整个调度器；支持环绕取时 |
| 2 | `api/_internal.py` | `_AUTH_HINTS` 收窄，业务「权限不足」不再误报成 API key 失效 |
| 3 | `cli/commands/*` | 错误/空结果改走 stderr（`notice()`），`-f json` 出错仍 pipe-clean |
| 4 | `notify/telegram.py` | 去掉 `parse_mode=Markdown`，含 `_` 用户名不再触发 400 静默丢通知 |

## 体验（#5）
| 5 | `cli/_table.py` | `unicodedata.east_asian_width`，全角标点正确双宽，表格不再错位 |

## 重构/优化（#6–#10）
| # | 文件 | 修复 |
|---|---|---|
| 6 | `cli/_query.py`(新) + `_account.py` | 抽 `run`/`fetch`/`maybe_raw` + `resolve_session_or_exit`，7 命令的错误/raw/会话逻辑收拢到一处，消除样板与漂移 |
| 7 | `cli/_emit.py` | `has_nested_values`：notices/hnr/messages 在 table/md 下遇嵌套字段提示用 `--raw`，不再输出 repr 垃圾 |
| 8 | `cli/commands/seeding.py` | userid 确为必需（探测确认），注明 `--uid` 可跳过 |
| 9 | `automation/login.py` | `_parse_profile` 复用 `api/humanize`，与 profile 命令格式一致 |
| 10 | `api/humanize.py` | `naturalsize` 用 `int(float(...))` 容忍浮点/科学计数字符串 |

## 验证
逐条单测 + 真实 API 实测：profile/search/seeding 重构后正常；`--raw` 仍输出完整嵌套；错误路径 `-f json` 的 stdout 保持空。`compileall` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)