### PR TITLE
ci: 推送 v* tag 时自动构建并发布 Docker 镜像

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Publish Docker image
+
+# Build and push bitwild/mteam-cli to Docker Hub when a version tag is pushed.
+#
+# Release flow:
+#   1. Bump `version` in pyproject.toml
+#   2. git tag v0.2.1 && git push origin v0.2.1
+#   The tag version must match pyproject.toml (the job fails otherwise) so the
+#   image tag, the git tag, and the package version never drift apart.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   DOCKERHUB_USERNAME — your Docker Hub username (e.g. bitwild)
+#   DOCKERHUB_TOKEN    — a Docker Hub access token with Read/Write scope
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  IMAGE_REPO: bitwild/mteam-cli
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Derive version from tag and verify it matches pyproject.toml
+        id: version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          proj_version="$(grep -m1 -E '^\s*version\s*=' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "Tag version:        $tag_version"
+          echo "pyproject version:  $proj_version"
+          if [ "$tag_version" != "$proj_version" ]; then
+            echo "::error::Tag v$tag_version does not match pyproject.toml version $proj_version. Bump pyproject.toml first."
+            exit 1
+          fi
+          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPO }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_REPO }}:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          # GitHub Actions cache speeds up repeat builds (pip layer reuse).
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
参考 Weread-CLI 的 `.github/workflows/docker-publish.yml`，为本项目添加同款发布流水线。

## 行为

推送 `v<version>` tag 时触发：
1. 从 tag 解析版本号，**校验与 `pyproject.toml` 一致**（不一致则失败，防止 tag/包/镜像版本漂移）；
2. `docker buildx` 构建（带 GHA 缓存复用 pip 层）；
3. 推送 `bitwild/mteam-cli:<version>` + `:latest` 到 Docker Hub，附 OCI 标签（version/source/revision）。

镜像仓库 `bitwild/mteam-cli` 与 `scripts/build-and-push.sh` 一致。

## 使用前提

仓库需配置两个 Secret（Settings → Secrets and variables → Actions）：
- `DOCKERHUB_USERNAME` — Docker Hub 用户名（如 `bitwild`）
- `DOCKERHUB_TOKEN` — 具备 Read/Write 权限的 Docker Hub access token

## 发版流程（此后）

```bash
# 1. bump pyproject.toml 的 version
# 2. 打 tag 并推送 → 自动构建发布
git tag v0.2.2 && git push origin v0.2.2
```

> 注：本 PR 合并后不会立即触发（只在 push tag 时触发）。当前 `v0.2.1` tag 已存在、不会回溯触发；下次 bump 版本打新 tag 即生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)