### PR TITLE
fix: 修复 PVC 写权限 + SMTP 502（0.2.2）

### DIFF
--- a/kubernetes-manifests/statefulset.yaml
+++ b/kubernetes-manifests/statefulset.yaml
@@ -36,7 +36,23 @@ spec:
         app: mteam-cli
     spec:
       securityContext:
+        # pwuser in the Playwright image is uid/gid 1000; the app runs as it.
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
+      # A freshly-provisioned PVC mounts root-owned and overlays the image's
+      # build-time chown, so the non-root app can't write /app/data. fsGroup
+      # fixes group perms on most CSI drivers but some ignore it — this
+      # initContainer chowns the mount as root, making it storage-independent.
+      initContainers:
+        - name: fix-data-perms
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 1000:1000 /app/data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
       containers:
         - name: mteam-cli
           image: bitwild/mteam-cli:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteam-cli"
-version = "0.2.1"
+version = "0.2.2"
 description = "M-Team CLI — keep-alive automation + AI-friendly data queries."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mteam_cli/__init__.py
+++ b/src/mteam_cli/__init__.py
@@ -1,3 +1,3 @@
 """M-Team CLI — keep-alive automation + AI-friendly data queries."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/mteam_cli/notify/smtp.py
+++ b/src/mteam_cli/notify/smtp.py
@@ -33,9 +33,15 @@ class SMTPNotifier:
         await asyncio.to_thread(self._sync_send, n)
 
     def _sync_send(self, n: Notification) -> None:
+        from email.utils import formataddr
+
         msg = MIMEText(n.body, _charset="utf-8")
         msg["Subject"] = f"[M-Team] {n.title}"
-        msg["From"] = f"MTeam-CLI <{self.sender}>"
+        # Header may carry a display name, but the SMTP envelope sender must be
+        # the bare address that matches the authenticated login user — QQ /
+        # Foxmail reject a mismatch with "502 Invalid parameters". So pass
+        # explicit from_addr/to_addrs (bare addresses) to send_message.
+        msg["From"] = formataddr(("MTeam-CLI", self.sender))
         msg["To"] = ", ".join(self.recipients)
 
         client_cls = smtplib.SMTP_SSL if self.port == 465 else smtplib.SMTP
@@ -44,5 +50,5 @@ class SMTPNotifier:
                 client.starttls()
             if self.user:
                 client.login(self.user, self.password)
-            client.send_message(msg)
+            client.send_message(msg, from_addr=self.sender, to_addrs=self.recipients)
         logger.info("SMTP 邮件已发送至 %s", ", ".join(self.recipients))


### PR DESCRIPTION
生产部署 0.2.1 镜像后发现两个问题，本 PR 修复并 bump 到 0.2.2。

## 1. k8s PVC 写权限 → PermissionError

**现象**：`PermissionError: [Errno 13] Permission denied: '/app/data/auth/mteam_Bytewild.json'`，保活无法保存 localStorage 快照。

**根因**：容器以非 root 的 `pwuser`(uid 1000) 运行；新建的 PVC 以 root 属主挂载，**覆盖**了镜像构建期 `chown -R pwuser /app` 的结果。`fsGroup: 1000` 在部分 CSI 驱动下不生效。

**修复**（`kubernetes-manifests/statefulset.yaml`）：
- 加 `initContainer`（busybox，root 身份 `chown -R 1000:1000 /app/data`）→ 与存储类无关地修复挂载属主；
- `securityContext` 显式 `runAsUser/runAsGroup=1000`（与 Playwright 镜像的 pwuser 一致）。

> compose 路径不受影响：命名卷首次创建会继承镜像里已 chown 的 `/app/data`。

## 2. SMTP 502 Invalid parameters

**现象**：`Notifier smtp failed: (502, b'Invalid paramenters', '')`，两个账户均失败。

**根因**：`send_message(msg)` 从 `From` 头解析信封发件人；QQ/Foxmail 对解析出的地址校验严格，`MTeam-CLI <addr>` 这种带显示名的头触发 `502 Invalid parameters`（[已知行为](https://bugs.python.org/issue32727)）。

**修复**（`notify/smtp.py`）：用 `email.utils.formataddr()` 规范化 `From` 头，并显式传 `from_addr=`/`to_addrs=`（裸地址）给 `send_message`，绕过头解析歧义。

## 验证
- statefulset YAML 解析通过，initContainer/securityContext 字段正确；
- smtp.py compile 通过，`formataddr` 输出正确，信封用裸地址。
- 部署后请确认：保活能写快照、SMTP 通知送达。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sources: [Python issue 32727](https://bugs.python.org/issue32727)