### PR TITLE
fix(k8s): pwuser UID 实为 1001 而非 1000

### DIFF
--- a/kubernetes-manifests/statefulset.yaml
+++ b/kubernetes-manifests/statefulset.yaml
@@ -36,10 +36,11 @@ spec:
         app: mteam-cli
     spec:
       securityContext:
-        # pwuser in the Playwright image is uid/gid 1000; the app runs as it.
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        # pwuser in the Playwright image is uid/gid 1001 (uid 1000 is `ubuntu`);
+        # the app runs as pwuser, so all of these must be 1001.
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       # A freshly-provisioned PVC mounts root-owned and overlays the image's
       # build-time chown, so the non-root app can't write /app/data. fsGroup
       # fixes group perms on most CSI drivers but some ignore it — this
@@ -47,7 +48,7 @@ spec:
       initContainers:
         - name: fix-data-perms
           image: busybox:1.36
-          command: ["sh", "-c", "chown -R 1000:1000 /app/data"]
+          command: ["sh", "-c", "chown -R 1001:1001 /app/data"]
           securityContext:
             runAsUser: 0
           volumeMounts:


### PR DESCRIPTION
## 问题

上一个 PR（#10）修 PVC 权限时假设 pwuser 是 uid 1000，但实际容器里：

```
ubuntu:x:1000:1000:...
pwuser:x:1001:1001:...   ← 应用真正运行的用户
```

uid 1000 是 `ubuntu`，pwuser 是 **1001**。所以之前的 `runAsUser/runAsGroup/fsGroup: 1000` 和 initContainer 的 `chown -R 1000:1000` 都把卷给了错误的用户，权限仍不对。

## 修复

`kubernetes-manifests/statefulset.yaml` 中全部 `1000` → `1001`（securityContext 三项 + initContainer chown）。

## 不影响镜像
仅 k8s 部署清单变更。Dockerfile 用 `pwuser` 名引用、manifest 不打进镜像，所以已发布的 `bitwild/mteam-cli:0.2.2`（含正确的 SMTP 修复）无需重建，**不 bump 版本**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)