### PR TITLE
fix(smtp): 修复 QQ 邮箱 550 内容过滤拒绝 — EmailMessage + 精简通知正文（0.2.3）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteam-cli"
-version = "0.2.2"
+version = "0.2.3"
 description = "M-Team CLI — keep-alive automation + AI-friendly data queries."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mteam_cli/__init__.py
+++ b/src/mteam_cli/__init__.py
@@ -1,3 +1,3 @@
 """M-Team CLI — keep-alive automation + AI-friendly data queries."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/src/mteam_cli/automation/runner.py
+++ b/src/mteam_cli/automation/runner.py
@@ -47,7 +47,7 @@ async def run_one_account_tick(
         Notification(
             event=event,
             title=title,
-            body=result.profile_text if result.ok else (result.error or "登录失败"),
+            body=_notify_body(result),
         )
     )
     return result
@@ -81,3 +81,18 @@ async def run_all_accounts(
             logger.exception("[%s] tick 异常，继续下一个账户", acct.username)
             worst = CHECKIN_FAILED_EXIT_CODE
     return worst
+
+
+def _notify_body(result: CheckinResult) -> str:
+    """Short notification body (email-safe — QQ's content filter rejects
+    full profile dumps). The detailed profile is in the log file."""
+    if result.ok:
+        body = f"{result.username} 保活签到成功。"
+        if result.profile_text:
+            # pull out only the last-login/browse lines (least triggering)
+            for line in result.profile_text.splitlines():
+                line = line.strip()
+                if "登录时间" in line or "浏览时间" in line:
+                    body += f"\n{line}"
+        return body
+    return result.error or "登录失败"

--- a/src/mteam_cli/cli/commands/login.py
+++ b/src/mteam_cli/cli/commands/login.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 
 from mteam_cli.automation.login import perform_login
+from mteam_cli.automation.runner import _notify_body
 from mteam_cli.cli._account import add_account_arg, require_keepalive, resolve_account_or_exit
 from mteam_cli.cli._browser import browser_session_ctx
 from mteam_cli.core.config import Settings
@@ -34,7 +35,7 @@ async def handle(
         Notification(
             event=event,
             title=title,
-            body=result.profile_text if result.ok else result.error,
+            body=_notify_body(result),
         )
     )
 

--- a/src/mteam_cli/notify/smtp.py
+++ b/src/mteam_cli/notify/smtp.py
@@ -1,5 +1,10 @@
-"""SMTP email notifier — stdlib smtplib, plain text. Recipients are fixed at
-construction time (per-account)."""
+"""SMTP email notifier — stdlib smtplib + email.message.EmailMessage.
+
+Follows the Weread-CLI pattern (proven working with QQ SMTP): modern
+``EmailMessage`` + ``set_content()`` for clean UTF-8 encoding; bare sender
+address on the envelope so QQ's strict auth check passes. Recipients are
+fixed at construction time (per-account).
+"""
 
 from __future__ import annotations
 
@@ -7,7 +12,7 @@ import asyncio
 import logging
 import smtplib
 from dataclasses import dataclass, field
-from email.mime.text import MIMEText
+from email.message import EmailMessage
 
 from mteam_cli.notify.base import Notification
 
@@ -33,16 +38,11 @@ class SMTPNotifier:
         await asyncio.to_thread(self._sync_send, n)
 
     def _sync_send(self, n: Notification) -> None:
-        from email.utils import formataddr
-
-        msg = MIMEText(n.body, _charset="utf-8")
-        msg["Subject"] = f"[M-Team] {n.title}"
-        # Header may carry a display name, but the SMTP envelope sender must be
-        # the bare address that matches the authenticated login user — QQ /
-        # Foxmail reject a mismatch with "502 Invalid parameters". So pass
-        # explicit from_addr/to_addrs (bare addresses) to send_message.
-        msg["From"] = formataddr(("MTeam-CLI", self.sender))
+        msg = EmailMessage()
+        msg["Subject"] = n.title
+        msg["From"] = self.sender
         msg["To"] = ", ".join(self.recipients)
+        msg.set_content(n.body)
 
         client_cls = smtplib.SMTP_SSL if self.port == 465 else smtplib.SMTP
         with client_cls(self.host, self.port, timeout=self.timeout_seconds) as client:
@@ -50,5 +50,5 @@ class SMTPNotifier:
                 client.starttls()
             if self.user:
                 client.login(self.user, self.password)
-            client.send_message(msg, from_addr=self.sender, to_addrs=self.recipients)
+            client.send_message(msg)
         logger.info("SMTP 邮件已发送至 %s", ", ".join(self.recipients))


### PR DESCRIPTION
## 问题

0.2.2 修复了 SMTP 502，但 QQ 继续拒绝邮件：

```
smtp failed: (550, b'The mail may contain inappropriate words or content.')
```

QQ 的 550 是**内容过滤**——通知正文包含 profile 完整转储（用户ID、登录IP、Email、上传量/下载量），触发反垃圾规则。

## 修复

### 1. smtp.py → Weread-CLI 模式（`EmailMessage` + `set_content()`）
- 改用现代 `EmailMessage` API（Weread-CLI 已证明对 QQ SMTP 可用）
- 净 UTF-8 编码，`Subject`/`From` 不再带额外标签
- `From` 头用裸地址（502 修复已在 0.2.2 生效，本次加固）

### 2. 通知正文精简（新增 `_notify_body()` helper）
**之前**（QQ 550 拒绝）：
```
用户ID: 278577
用户名: riddd
用户Email: ridddzl@gmail.com
登录IP: 171.15.221.46
账户创建时间: 2022-10-02 23:01:17
上传量: 20.4 TiB
下载量: 5.6 TiB
魔力值: 1631.7
分享率: 3.633
```

**之后**（极简，通过过滤）：
```
riddd 保活签到成功。
会员最新登录时间: 2026-06-04 09:22:24
会员最新浏览时间: 2026-06-04 09:22:24
```

完整 profile 仍在 `mteam-cli login` stdout 和日志文件中可查。

## 验证
- `_notify_body` 单测通过：无 IP/Email/用户ID/上传/下载
- `compileall` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)