### PR TITLE
ci: 消除 Node.js 20 弃用告警

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,8 @@ on:
 
 env:
   IMAGE_REPO: bitwild/mteam-cli
+  # Opt into Node.js 24 runtime ahead of the June 2026 default switch.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   publish:


### PR DESCRIPTION
GitHub Actions 将于 2026-09 移除 Node.js 20 运行时。加入 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` 环境变量，提前迁移到 Node.js 24。仅 workflow 变更，不影响镜像。\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)