### PR TITLE
docs: 记录 NOTIFY_SMTP_FROM 双重包装导致 QQ 502 的陷阱

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,6 +32,8 @@ NOTIFY_SMTP_TO_1=
 
 # ── SMTP 服务器（全局，所有账户共享；收件人按账户 NOTIFY_SMTP_TO_<n>）───
 # 465=SSL，587=STARTTLS。密码用授权码而非登录密码。
+# NOTIFY_SMTP_FROM 只填纯邮箱地址（如 user@foxmail.com）。程序已自动加
+# "MTeam-CLI <addr>" 显示名；如果这里再写显示名，会被双重包装导致 QQ 502。
 NOTIFY_SMTP_HOST=
 NOTIFY_SMTP_PORT=465
 NOTIFY_SMTP_USER=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ mteam-cli notices [-n N]
 
 Per account `_i`:
 - Credentials (independent sets): `MTEAM_USERNAME_i` + `MTEAM_PASSWORD_i` + `MTEAM_TOTP_SECRET_i` → `can_keepalive`; `MTEAM_API_KEY_i` → `can_query`.
-- **Notify, also per-account** (each channel opts in on its own vars): `NOTIFY_TELEGRAM_TOKEN_i`+`NOTIFY_TELEGRAM_CHAT_ID_i`, `NOTIFY_FEISHU_TOKEN_i`, `NOTIFY_SMTP_HOST_i`/`_PORT_i`/`_USER_i`/`_PASSWORD_i`/`_FROM_i`/`_TO_i`/`_USE_TLS_i` (`NOTIFY_EMAIL_i` is accepted as an alias for `NOTIFY_SMTP_TO_i`). Exposed as `Account.has_telegram` / `has_smtp` / `has_feishu`.
+- **Notify, also per-account** (each channel opts in on its own vars): `NOTIFY_TELEGRAM_TOKEN_i`+`NOTIFY_TELEGRAM_CHAT_ID_i`, `NOTIFY_FEISHU_TOKEN_i`, `NOTIFY_SMTP_TO_i` (`NOTIFY_EMAIL_i` is accepted as an alias for `NOTIFY_SMTP_TO_i`). SMTP *server* is global (`NOTIFY_SMTP_HOST`/`_PORT`/`_USER`/`_PASSWORD`/`_FROM`/`_USE_TLS`, no suffix). Exposed as `Account.has_telegram` / `has_smtp` / `has_feishu`.
 
 An api-key-only account is valid (data-only); a password+totp-only account is valid (keep-alive-only). The parser stops at the first index with neither username nor api_key. Commands call `require_keepalive` / `require_query` and exit clearly when the needed credential is missing.
 
@@ -104,6 +104,7 @@ Verified against M-Team's OpenAPI spec (`https://test2.m-team.cc/api/swagger-ui/
 - **Data ≠ keep-alive identity.** Data commands use `api_key`; keep-alive uses browser session. Don't entangle the two transports.
 - **M-Team API shapes are probe-verified.** When an endpoint differs from `api/public.py`'s current assumption (path/method/body/`code`/fields), fix it there — never spread the assumption into command modules. Re-probe by capturing the SPA's real XHR (DevTools / `page.route`).
 - **localStorage, not storage_state**, is the auth persistence format for M-Team.
+- **NOTIFY_SMTP_FROM must be a bare email address** (e.g. `user@foxmail.com`), NOT `DisplayName <addr>`. The code wraps it into `"MTeam-CLI <{sender}>"` for the From header; if sender already contains a display name, the double-wrapped result (e.g. `MTeam-CLI <MTeam-CLI<addr>>`) is syntactically invalid. smtplib can't extract a clean envelope address, and QQ/Foxmail SMTP returns `502 Invalid paramenters`. This was discovered the hard way: the dev-machine `.env` had a bare address (works); the k8s StatefulSet had a display-name value (502). The symptom on a dev machine with a working config is invisible — test in the real deployment environment.
 
 ## Deployment
 

--- a/src/mteam_cli/notify/smtp.py
+++ b/src/mteam_cli/notify/smtp.py
@@ -1,9 +1,13 @@
 """SMTP email notifier — stdlib smtplib + MIMEText.
 
-Matches the legacy MT-AutoCheckIn script's proven SMTP pattern (the same code
-has been sending through QQ/Foxmail SMTP for years without content-filter
-rejections). ``EmailMessage.set_content()`` was tried — it triggered QQ 550 —
-so this sticks with ``MIMEText`` and plain-string headers.
+From header is ``"MTeam-CLI <{sender}>"`` — sender is expected to be a plain
+email address (e.g. ``user@foxmail.com``). If sender already carries a display
+name, the double-wrapping produces a syntactically invalid header that smtplib
+can't parse into a clean envelope address, and QQ/Foxmail SMTP returns
+``502 Invalid paramenters``. Keep NOTIFY_SMTP_FROM as a bare address.
+
+This is the legacy script's proven pattern — MIMEText with a single-layer
+display-name From header. It has worked with QQ/Foxmail SMTP for years.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
仅文档，不 bump 版本。记录 SMTP From 双包包装的排查结论。\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)